### PR TITLE
Fix/memory explosion

### DIFF
--- a/include/seer.hrl
+++ b/include/seer.hrl
@@ -5,14 +5,13 @@
 -define(ENV_POLL_INTERVAL, poll_interval).
 -define(ENV_CARBON_HOST, carbon_host).
 -define(ENV_CARBON_PORT, carbon_port).
--define(ENV_MAX_BUFFER_SIZE, max_buffer_size).
 -define(DEFAULT_PREFIX, <<"seer">>).
 -define(DEFAULT_MODE, carbon).
 -define(DEFAULT_POLL_INTERVAL, 10000).
 -define(DEFAULT_CARBON_HOST, localhost).
 -define(DEFAULT_CARBON_PORT, 2003).
--define(DEFAULT_MAX_BUFFER_SIZE, 60).
 -define(TCP_RECONNECTION_INTERVAL, 250).
+-define(MAX_BUFFER_MEMORY, 2621440). % translates to 20 MB on 64bit architecture
 
 -type carbon_string() :: binary().
 -type carbon_batch() :: [carbon_string()].

--- a/include/seer.hrl
+++ b/include/seer.hrl
@@ -20,6 +20,7 @@
 -type metric_type() :: counter | gauge | dist | histo | dist_timing | histo_timing.
 -type read_value() :: term().
 -type read_metric() :: {metric_type(), metric_name(), read_value()}.
+-type metric_batch() :: {[read_metric()], erlang:timestamp()}.
 -type histo_bucket_key() :: {non_neg_integer(), non_neg_integer()}.
 -type histo_bucket() :: {histo_bucket_key(), non_neg_integer()}.
 -type histo_percentile() :: p50 | p90 | p99.

--- a/src/seer.erl
+++ b/src/seer.erl
@@ -58,9 +58,10 @@ read(Type, Name) ->
     {ok, Ref} = get(Type, Name),
     {ok, read_metric(Type, Name, Ref)}.
 
--spec read_all() -> [{metric_type(), metric_name(), read_value()}].
+-spec read_all() -> metric_batch().
 read_all() ->
-    [{Type, Name, read_metric(Type, Name, Ref)} || {{?MODULE, Name}, {Type, Ref}} <- persistent_term:get()].
+    {[{Type, Name, read_metric(Type, Name, Ref)} || {{?MODULE, Name}, {Type, Ref}} <- persistent_term:get()],
+     erlang:timestamp()}.
 
 % private
 -spec dist_record2(atomics:atomics_ref(), integer(), integer()) -> ok | {error, term()}.

--- a/src/seer_server.erl
+++ b/src/seer_server.erl
@@ -54,13 +54,13 @@ handle_info(setup, #state{mode = Mode, poll_interval = Interval} = State) ->
     timer:send_after(Interval, Msg),
     {noreply, SetupState};
 handle_info(poll_stdout, #state{poll_interval = Interval} = State) ->
-    Metrics = seer:read_all(),
+    {Metrics, _Timestamp} = seer:read_all(),
     io:format("~w~n", [Metrics]),
     timer:send_after(Interval, poll_stdout),
     {noreply, State};
 handle_info(poll_carbon,
             #state{prefix = Prefix, host = Host, tcp_socket = Socket, poll_interval = Interval} = State) ->
-    Metrics = seer:read_all(),
+    {Metrics, _Timestamp} = seer:read_all(),
     CarbonStrings = seer_utils:carbon_format(Prefix, Host, Metrics),
     case carbon_send_batch(Socket, CarbonStrings) of
       ok ->
@@ -82,7 +82,7 @@ handle_info(poll_carbon_offline,
                    buffer_size = BufferSize,
                    max_buffer_size = MaxBufferSize} =
                 State) ->
-    Metrics = seer:read_all(),
+    {Metrics, _Timestamp} = seer:read_all(),
     CarbonStrings = seer_utils:carbon_format(Prefix, Host, Metrics),
     {NewBuffer, NewBufferSize} = case BufferSize < MaxBufferSize of
                                    true ->

--- a/test/seer_test.erl
+++ b/test/seer_test.erl
@@ -45,18 +45,22 @@ histo_record_test() ->
 read_all_test() ->
     ok = seer:counter_inc(<<"bob_the_counter">>, 10),
     ok = seer:gauge_set(<<"bob_the_gauge">>, 5),
+
+    {Metrics, _Timestamp} = seer:read_all(),
     Map = lists:foldl(fun ({Type, Name, Val}, Acc) ->
                               Acc#{{Type, Name} => Val}
                       end,
                       #{},
-                      seer:read_all()),
+                      Metrics),
     ?assertMatch(#{{counter, <<"bob_the_counter">>} := 10}, Map),
     ?assertMatch(#{{gauge, <<"bob_the_gauge">>} := 5}, Map),
+
+    {Metrics2, _Timestamp2} = seer:read_all(),
     Map2 = lists:foldl(fun ({Type, Name, Val}, Acc) ->
                                Acc#{{Type, Name} => Val}
                        end,
                        #{},
-                       seer:read_all()),
+                       Metrics2),
     ?assertMatch(#{{counter, <<"bob_the_counter">>} := 0}, Map2),
     ?assertMatch(#{{gauge, <<"bob_the_gauge">>} := 5}, Map2).
 


### PR DESCRIPTION
When the connection to carbon is lost, the buffered metrics can become very large. This PR aims to mitigate this problem by buffering the metrics themselves instead of their string representation.