### PR TITLE
Feature/carbon counter rate

### DIFF
--- a/include/seer.hrl
+++ b/include/seer.hrl
@@ -8,11 +8,11 @@
 -define(ENV_MAX_BUFFER_SIZE, max_buffer_size).
 -define(DEFAULT_PREFIX, <<"seer">>).
 -define(DEFAULT_MODE, carbon).
--define(DEFAULT_POLL_INTERVAL, 10000).
+-define(DEFAULT_POLL_INTERVAL, 10).
 -define(DEFAULT_CARBON_HOST, localhost).
 -define(DEFAULT_CARBON_PORT, 2003).
 -define(DEFAULT_MAX_BUFFER_SIZE, 60).
--define(TCP_RECONNECTION_INTERVAL, 250).
+-define(TCP_RECONNECTION_INTERVAL, 10000).
 
 -type carbon_string() :: binary().
 -type carbon_batch() :: [carbon_string()].

--- a/src/seer_server.erl
+++ b/src/seer_server.erl
@@ -28,10 +28,11 @@ init(_) ->
                 Name when is_binary(Name) ->
                     Name
               end,
+    Interval = ?ENV(?ENV_POLL_INTERVAL, ?DEFAULT_POLL_INTERVAL) * 1000,
     InitialState = #state{mode = ?ENV(?ENV_MODE, ?DEFAULT_MODE),
                           prefix = ?ENV(?ENV_PREFIX, ?DEFAULT_PREFIX),
                           host = BinHost,
-                          poll_interval = ?ENV(?ENV_POLL_INTERVAL, ?DEFAULT_POLL_INTERVAL),
+                          poll_interval = Interval,
                           max_buffer_size = ?ENV(?ENV_MAX_BUFFER_SIZE, ?DEFAULT_MAX_BUFFER_SIZE)},
     self() ! setup,
     {ok, InitialState}.

--- a/src/seer_utils.erl
+++ b/src/seer_utils.erl
@@ -20,7 +20,7 @@ format_carbon_line(Prefix, Host, {Type, Name, Value}, Timestamp) ->
       _ ->
           case Type of
             counter ->
-                format_carbon_line(<<MetricKey/binary, ".counter">>, integer_to_binary(Value), TimestampBin);
+                counter_carbon_line(<<MetricKey/binary, ".counter">>, Value, TimestampBin);
             gauge ->
                 format_carbon_line(<<MetricKey/binary, ".gauge">>, integer_to_binary(Value), TimestampBin);
             dist ->
@@ -33,6 +33,13 @@ format_carbon_line(Prefix, Host, {Type, Name, Value}, Timestamp) ->
                 histo_carbon_line(<<MetricKey/binary, ".histo_timing">>, Value, TimestampBin)
           end
     end.
+
+-spec counter_carbon_line(binary(), integer(), binary()) -> [carbon_string()].
+counter_carbon_line(MetricKey, Value, TsBin) ->
+    NbSec = ?ENV(?ENV_POLL_INTERVAL, ?DEFAULT_POLL_INTERVAL),
+    Rate = Value div NbSec,
+    [format_carbon_line(MetricKey, integer_to_binary(Value), TsBin),
+     format_carbon_line(<<MetricKey/binary, ".rate">>, integer_to_binary(Rate), TsBin)].
 
 -spec dist_carbon_line(binary(), map(), binary()) -> [carbon_string()].
 dist_carbon_line(MetricKey, Value, TsBin) ->


### PR DESCRIPTION
This PR adds a "rate" metric to the counters exposed via carbon, which represent the amount per second for a given polling period.

It also changes the interval parameter from milliseconds to seconds.

The default re-connection interval has been changed from 250 ms to 10 seconds.